### PR TITLE
Add option to store shared keys for wireshark analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ $ ./tls-perf --help
   --tls <version>   Set TLS version for handshake: '1.2', '1.3' or 'any' for both (default: '1.2')
   --tickets <mode>  Process TLS Session tickets and session resumption,
                     'on', 'off' or 'advertise', (default: 'off')
+  --keylogfile <f>  File to dump keys for traffic analysers
 
 127.0.0.1:443 address is used by default.
 


### PR DESCRIPTION
Just a simple option to simplify debugging on the server side: the master secret is dumped to a file for every TLS connection, allowing to check the traffic inside Wireshark. Sometimes useful, but not so much since just a few messages are encrypted during handshake: `Finished` and`Alert`.