### PR TITLE
tls-perf was using epoll incorrectly always triggering on read/write events

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -411,12 +411,11 @@ private:
 	SSL_SESSION		*sess_;
 	std::chrono::time_point<std::chrono::steady_clock> ts_;
 	enum _states		state_;
-	bool			polled_;
 
 public:
 	Peer(IO &io, int id) noexcept
 		: io_(io), id_(id), tls_(NULL), sess_(NULL)
-		, state_(STATE_TCP_CONNECT), polled_(false)
+		, state_(STATE_TCP_CONNECT)
 	{
 		sd = -1;
 		dbg_status("created");

--- a/main.cc
+++ b/main.cc
@@ -315,9 +315,9 @@ public:
 			.data = { .ptr = sh }
 		};
 
-		if (epoll_ctl(ed_, EPOLL_CTL_ADD, sh->sd, &ev) < 0) {
-			if (errno == EEXIST &&
-			    epoll_ctl(ed_, EPOLL_CTL_MOD, sh->sd, &ev) < 0)
+		if (epoll_ctl(ed_, EPOLL_CTL_MOD, sh->sd, &ev) < 0) {
+			if (errno == ENOENT &&
+			    epoll_ctl(ed_, EPOLL_CTL_ADD, sh->sd, &ev) < 0)
 			{
 				throw Except("can't add socket to poller");
 			}
@@ -452,16 +452,6 @@ public:
 	}
 
 private:
-	/*
-	void
-	add_to_poll()
-	{
-		if (!polled_) {
-			io_.add(this);
-			polled_ = true;
-		}
-	}
-	*/
 	void
 	poll_for_read()
 	{
@@ -477,10 +467,7 @@ private:
 	void
 	del_from_poll()
 	{
-		if (polled_) {
-			io_.del(this);
-			polled_ = false;
-		}
+		io_.del(this);
 	}
 
 	void


### PR DESCRIPTION
This could be noticed from strace-ing:
```
[pid 48660] connect(4, {sa_family=AF_INET, sin_port=htons(1443), sin_addr=inet_addr("127.0.0.1")}, 16) = -1 EINPROGRESS (Operation now in progress)
[pid 48660] epoll_ctl(3, EPOLL_CTL_ADD, 4, {EPOLLIN|EPOLLOUT|EPOLLERR, {u32=2751729632, u64=139911311396832}}) = 0
[pid 48660] epoll_wait(3, [{EPOLLOUT, {u32=2751729632, u64=139911311396832}}], 128, 5) = 1
[pid 48660] getsockopt(4, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
[pid 48660] setsockopt(4, SOL_TCP, TCP_NODELAY, [1], 4) = 0
[pid 48660] write(4, "\26\3\1\0\207\1\0\0\203\3\3g\355;\301\306\10\301\16\351P\342\16R\314xh\317\344\214\315b"..., 140) = 140
[pid 48660] read(4, 0x7f3fa4048993, 5)  = -1 EAGAIN (Resource temporarily unavailable)
[pid 48660] epoll_wait(3, [{EPOLLOUT, {u32=2751729632, u64=139911311396832}}], 128, 5) = 1
[pid 48660] read(4, 0x7f3fa4048993, 5)  = -1 EAGAIN (Resource temporarily unavailable)
[pid 48660] epoll_wait(3, [{EPOLLOUT, {u32=2751729632, u64=139911311396832}}], 128, 5) = 1
[pid 48660] read(4, 0x7f3fa4048993, 5)  = -1 EAGAIN (Resource temporarily unavailable)
[pid 48660] epoll_wait(3, [{EPOLLOUT, {u32=2751729632, u64=139911311396832}}], 128, 5) = 1
[pid 48660] read(4, 0x7f3fa4048993, 5)  = -1 EAGAIN (Resource temporarily unavailable)
[pid 48660] epoll_wait(3, [{EPOLLOUT, {u32=2751729632, u64=139911311396832}}], 128, 5) = 1
[pid 48660] read(4, 0x7f3fa4048993, 5)  = -1 EAGAIN (Resource temporarily unavailable)
[pid 48660] epoll_wait(3, [{EPOLLOUT, {u32=2751729632, u64=139911311396832}}], 128, 5) = 1
[pid 48660] read(4, 0x7f3fa4048993, 5)  = -1 EAGAIN (Resource temporarily unavailable)
[pid 48660] epoll_wait(3, [{EPOLLOUT, {u32=2751729632, u64=139911311396832}}], 128, 5) = 1
[pid 48660] read(4, 0x7f3fa4048993, 5)  = -1 EAGAIN (Resource temporarily unavailable)
```

I've changed this slightly by using appropriate combination of EPOLLIN/EPOLLOUT flags with EPOLLONESHOT for easiness.
The implementation is quite "quick'n'dirty", so this comes at the cost of extra syscall on first adding descriptor to the epoll like this:
```
[pid 49907] connect(4, {sa_family=AF_INET, sin_port=htons(1443), sin_addr=inet_addr("127.0.0.1")}, 16) = -1 EINPROGRESS (Operation now in progress)
[pid 49907] epoll_ctl(3, EPOLL_CTL_MOD, 4, {EPOLLOUT|EPOLLERR|EPOLLONESHOT, {u32=201592800, u64=139895876358112}}) = -1 ENOENT (No such file or directory)
[pid 49907] epoll_ctl(3, EPOLL_CTL_ADD, 4, {EPOLLOUT|EPOLLERR|EPOLLONESHOT, {u32=201592800, u64=139895876358112}}) = 0
```